### PR TITLE
Misc minor fixes

### DIFF
--- a/bin/complete.fish
+++ b/bin/complete.fish
@@ -1,3 +1,3 @@
 #!/usr/bin/env fish
 
-complete --do-complete="$argv" | grep -v "^$argv\$" | uniq
+complete --do-complete="$argv" | string match -rv '^'(string escape --style=regex "$argv")'(\s|$)' | uniq

--- a/rplugin/python3/deoplete/sources/deoplete_fish.py
+++ b/rplugin/python3/deoplete/sources/deoplete_fish.py
@@ -14,6 +14,7 @@ class Source(Base):
         self.mark = '[fish]'
         self.filetypes = ['fish']
         self.input_pattern = r'[^. \t0-9]\.\w*'
+        self.is_volatile = True
         self.rank = 500
         self.__executable_fish = self.vim.call('executable', 'fish')
 

--- a/rplugin/python3/deoplete/sources/deoplete_fish.py
+++ b/rplugin/python3/deoplete/sources/deoplete_fish.py
@@ -13,7 +13,7 @@ class Source(Base):
         self.name = 'fish'
         self.mark = '[fish]'
         self.filetypes = ['fish']
-        self.input_pattern = '[^. \t0-9]\.\w*'
+        self.input_pattern = r'[^. \t0-9]\.\w*'
         self.rank = 500
         self.__executable_fish = self.vim.call('executable', 'fish')
 


### PR DESCRIPTION
Note in the third commit I also made a minor change to the regex ('$' changed to '(\s|$)') so that we filter out completions that exactly match the user input even if the completion candidate has a description.


In other words, previously after typing "exec" the completion for "exec" wouldn't be filtered out because exec has a description.

```
$ complete --do-complete="exec"
execute
exec	Run command in current process
```