### PR TITLE
Revert "Fix completion candidates not updating."

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_fish.py
+++ b/rplugin/python3/deoplete/sources/deoplete_fish.py
@@ -14,7 +14,6 @@ class Source(Base):
         self.mark = '[fish]'
         self.filetypes = ['fish']
         self.input_pattern = r'[^. \t0-9]\.\w*'
-        self.is_volatile = True
         self.rank = 500
         self.__executable_fish = self.vim.call('executable', 'fish')
 


### PR DESCRIPTION
Apologies for the churn.
See: https://github.com/Shougo/deoplete.nvim/commit/a61c35a267d385036f6747207146422f16f68f29#commitcomment-36629826

> I misunderstood how deoplete works in regards to caching/filtering and the
> change to how sources that have not set is_volatile are handled is indeed
> desireable.
> 
> If is_volatile is not set for the source then gather_candidates is only called
> for the initial completion (i.e. when min_pattern_length is reached) and further
> modifications of the PUM candidates are managed by filters.
> 
> This is how fuzzy filters are able to work.
> If is_volatile is set then the candidates from 'complete --do-complete' are updated for
> all user input, which means we will only ever have exact prefix matches (e.g. no
> fuzzy filtering).
> 
> This reverts commit a8369cb9d790c090ab38a4c91c38b9754debec8a.