### PR TITLE
Complete also starts at whitespace

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_fish.py
+++ b/rplugin/python3/deoplete/sources/deoplete_fish.py
@@ -13,12 +13,12 @@ class Source(Base):
         self.name = 'fish'
         self.mark = '[fish]'
         self.filetypes = ['fish']
-        self.input_pattern = r'[^. \t0-9]\.\w*'
+        self.input_pattern = r'[^.\t0-9]\.\w*'
         self.rank = 500
         self.__executable_fish = self.vim.call('executable', 'fish')
 
     def get_complete_position(self, context):
-        m = re.search(r'\S+$', context['input'])
+        m = re.search(r'\S*$', context['input'])
         return m.start() if m else -1
 
     def gather_candidates(self, context):


### PR DESCRIPTION
This is useful for using `g:deoplete#manual_complete()` to complete subcommands.

For example: `git <ctrl-space>` to get the list of subcommands under git.

This change also doesn't affect any users who aren't using manual complete, so a fairly safe change.